### PR TITLE
fix for x button overflow

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -102,7 +102,7 @@ const Navbar = () => {
       {/* Overlay */}
       <div
         className={
-          nav ? 'md:hidden fixed left-0 top-0 w-full h-screen bg-black/70' : ''
+          nav ? 'md:hidden fixed left-0 top-0 w-full h-screen bg-black/70' : 'invisible'
         }
       >
         {/* Side Drawer Menu */}


### PR DESCRIPTION
![localhost_3000_(iPhone 4)](https://user-images.githubusercontent.com/39207179/211703358-0931043e-7158-49a2-a38e-69369c4b1efd.png)

When viewing on mobile devices with small viewpoints, the close button will appear when it should not. This fixes that issue without breaking the side menu.
